### PR TITLE
Add jupyter book for docs

### DIFF
--- a/.github/workflows/build_book.yaml
+++ b/.github/workflows/build_book.yaml
@@ -1,36 +1,60 @@
 name: deploy-book
 
-# Only run this when the master branch changes
+# Run this when the master or main branch changes
 on:
   push:
     branches:
     - master
     - main
+    # If your git repository has the Jupyter Book within some-subfolder next to
+    # unrelated files, you can make this run only if a file within that specific
+    # folder has been modified.
+    #
+    # paths:
+    # - some-subfolder/**
 
-# This job installs dependencies, build the book, and pushes it to `gh-pages`
+# This job installs dependencies, builds the book, and pushes it to `gh-pages`
 jobs:
   deploy-book:
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Install dependencies
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: '3.11'
+        cache: pip # Implicitly uses requirements.txt for cache key
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r ./docs/requirements.txt
+      run: pip install -r requirements.txt
+
+    # (optional) Cache your executed notebooks between runs
+    # if you have config:
+    # execute:
+    #   execute_notebooks: cache
+    - name: cache executed notebooks
+      uses: actions/cache@v4
+      with:
+        path: _build/.jupyter_cache
+        key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
+
     # Build the book
     - name: Build the book
       run: |
-        jupyter-book build docs/
-    # Push the book's HTML to github-pages
-    - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.5.9
+        jupyter-book build .
+
+    # Upload the book's HTML as an artifact
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/_build/html
+        path: "_build/html"
+
+    # Deploy the book's HTML to GitHub Pages
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/build_book.yaml
+++ b/.github/workflows/build_book.yaml
@@ -1,0 +1,36 @@
+name: deploy-book
+
+# Only run this when the master branch changes
+on:
+  push:
+    branches:
+    - master
+    - main
+
+# This job installs dependencies, build the book, and pushes it to `gh-pages`
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    # Install dependencies
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ./docs/requirements.txt
+    # Build the book
+    - name: Build the book
+      run: |
+        jupyter-book build docs/
+    # Push the book's HTML to github-pages
+    - name: GitHub Pages action
+      uses: peaceiris/actions-gh-pages@v3.5.9
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/_build/html

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,20 @@
+# In _config.yml
+title: SOLS-processing
+author: Sebastian Bundschuh, Johannes Soltwedel, Nazar Oleksiievets
+logo: logo.png
+execute:
+  execute_notebooks: off
+
+# Add a bibtex file so that we can create citations
+bibtex_bibfiles:
+  - references.bib
+
+sphinx:
+  extra_extensions:
+  - 'sphinx.ext.autodoc'
+  - 'sphinx.ext.napoleon'
+  - 'sphinx.ext.viewcode'
+  - 'sphinx.ext.autosummary'
+  config:
+    add_module_names: True
+    autosummary_generate: True

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,0 +1,8 @@
+# Table of contents
+# Learn more at https://jupyterbook.org/customize/toc.html
+
+format: jb-book
+root: intro
+
+options:
+  numbered: False

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,1 +1,3 @@
 # SOLS processing
+
+Welcome to the documentation pages of SOLS-processing!

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,1 @@
+# SOLS processing

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+jupyter-book


### PR DESCRIPTION
This pull request sets up the deployment process for the SOLS-processing documentation using GitHub Actions and configures the Jupyter Book project. The most important changes include adding a GitHub Actions workflow to build and deploy the book, configuring the Jupyter Book project, and setting up the table of contents and introduction page.

Deployment setup:

* [`.github/workflows/build_book.yaml`](diffhunk://#diff-72ccaf567f659af5f48135c34aa6e30fedcb8d71cedfea54b6cedf509b77f66aR1-R36): Added a GitHub Actions workflow to build the Jupyter Book and deploy it to GitHub Pages.

Jupyter Book configuration:

* [`docs/_config.yml`](diffhunk://#diff-f64371f310bcd3bbf6ead5827d929a4eb13b7516806d6658485a996e39eb2556R1-R20): Configured the Jupyter Book project with the title, authors, logo, and Sphinx extensions.
* [`docs/_toc.yml`](diffhunk://#diff-4f938c2f382334bbe68d17da3c7582b77496a7bf3a4d6c2ff53d1c073500e163R1-R8): Added a table of contents configuration for the Jupyter Book.
* [`docs/intro.md`](diffhunk://#diff-22760d417a52c66f14bee182587d458d0737a616dd14cb09748b4c725fc5809fR1-R3): Created an introduction page for the documentation.
* [`docs/requirements.txt`](diffhunk://#diff-2c9c11d26b09b8afde329980309d967121543a456e4592c76886a20b5cf56c90R1): Added `jupyter-book` to the requirements file.