### PR TITLE
fix jupyter-book workflow

### DIFF
--- a/.github/workflows/build_book.yaml
+++ b/.github/workflows/build_book.yaml
@@ -31,7 +31,7 @@ jobs:
         cache: pip # Implicitly uses requirements.txt for cache key
 
     - name: Install dependencies
-      run: pip install -r requirements.txt
+      run: pip install -r docs/requirements.txt
 
     # (optional) Cache your executed notebooks between runs
     # if you have config:


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/build_book.yaml` file, specifically in the `jobs:` section. The change updates the path to the requirements file used for installing dependencies.

* [`.github/workflows/build_book.yaml`](diffhunk://#diff-72ccaf567f659af5f48135c34aa6e30fedcb8d71cedfea54b6cedf509b77f66aL34-R34): Updated the path for installing dependencies to use `docs/requirements.txt` instead of `requirements.txt`.