### PR TITLE
build from correct folder

### DIFF
--- a/.github/workflows/build_book.yaml
+++ b/.github/workflows/build_book.yaml
@@ -46,7 +46,7 @@ jobs:
     # Build the book
     - name: Build the book
       run: |
-        jupyter-book build .
+        jupyter-book build docs/
 
     # Upload the book's HTML as an artifact
     - name: Upload artifact


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/build_book.yaml` file to update the path used in the `jupyter-book build` command.

* [`.github/workflows/build_book.yaml`](diffhunk://#diff-72ccaf567f659af5f48135c34aa6e30fedcb8d71cedfea54b6cedf509b77f66aL49-R49): Changed the path from the current directory to the `docs/` directory in the `jupyter-book build` command.